### PR TITLE
feature/#16 - Enforce new PR/Branch/Commit naming standards

### DIFF
--- a/.git-custom/hooks/commit-msg
+++ b/.git-custom/hooks/commit-msg
@@ -44,24 +44,24 @@ fi
 
 # Enforce: type#123 - Message
 # Allowed types: doc, ftr, bug, refactor, chore, sandbox
-PATTERN='^(document|feature|bugfix|refactor|chore|sandbox)#[0-9]+ - .+'
+PATTERN='^(document|feature|bugfix|refactor|chore|sandbox)/#[0-9]+ - .+'
 
 if [[ ! "$SUBJECT" =~ $PATTERN ]]; then
   cat >&2 <<EOF
 $(red "✖ Invalid commit message format.")
 
 Expected:
-  $(ylw $(underline doc))#$(issue_id) - Commit message for documentation
-  $(ylw $(underline ftr))#$(issue_id) - Commit message for features
-  $(ylw $(underline bug))#$(issue_id) - Commit message for bug fixes
-  $(ylw $(underline refactor))#$(issue_id) - Commit message for refactoring
-  $(ylw $(underline chore))#$(issue_id) - Commit message for misc (dep update)
-  $(ylw $(underline sandbox))#$(issue_id) - Commit message for sandboxing (testing only)
+  $(ylw $(underline document))/#$(issue_id) - Commit message for documentation
+  $(ylw $(underline feature))/#$(issue_id) - Commit message for features
+  $(ylw $(underline bugfix))/#$(issue_id) - Commit message for bug fixes
+  $(ylw $(underline refactor))/#$(issue_id) - Commit message for refactoring
+  $(ylw $(underline chore))/#$(issue_id) - Commit message for misc (dep update)
+  $(ylw $(underline sandbox))/#$(issue_id) - Commit message for sandboxing (testing only)
 
 Examples:
-  $(ylw $(underline ftr))#$(cyn 123) - Add S3 bootstrap for k3s nodes
-  $(ylw $(underline bug))#$(cyn 264) - Fix token fetch from SSM
-  $(ylw $(underline doc))#$(cyn 3908) - Update README with cost comparison
+  $(ylw $(underline feature))/#$(cyn 123) - Add S3 bootstrap for k3s nodes
+  $(ylw $(underline bugfix))/#$(cyn 264) - Fix token fetch from SSM
+  $(ylw $(underline document))/#$(cyn 3908) - Update README with cost comparison
 
 Notes:
   - $(issue_id) is the relevant GitHub Issue Number (e.g. #123)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,12 +86,12 @@ The rules are kept short and easy to follow, failure to follow will likely lead 
 
 ```
 Breakdown: (Title)
-    BRANCH_TYPE#ISSUE_ID PR_TITLE
+    TYPE/#ISSUE_ID PR_TITLE
 
 Example: (Assume 'bugfix' type and issue id is '#12345')
-    bugfix#12345 Fix a bug
+    bugfix/#12345 Fix a bug
 
-See the BRANCH_TYPE via the Branch Guide
+See the TYPE via the Commit Guide
 ```
 
 **Keep your PRs:**
@@ -110,42 +110,36 @@ See the BRANCH_TYPE via the Branch Guide
 ## Branch Guide
 ```
 Breakdown:
-    BRANCH_TYPE#ISSUE_ID_BRANCH_NAME
+    TYPE/#ISSUE_ID_BRANCH_NAME
 
 Example: (Assume 'bugfix' type and issue id is '#12345')
-    bugfix#12345_fix_a_bug
+    bugfix/#12345_fix_a_bug
 
 Command:
-    git checkout -b "bugfix#12345_fix_a_bug"
-```
+    git checkout -b "bugfix/#12345_fix_a_bug"
 
-**Branch Types**
-- `document`    : Documentation
-- `feature`     : Feature
-- `bugfix`      : Bug Fix
-- `refactor`    : Refactorization
-- `chore`       : Misc (Dependency updates, etc)
-- `sandbox`     : Test branch to freely experiment (Not allowed for PRs)
+See the TYPE via the Commit Guide
+```
 
 ## Commit Guide
 ```
 Breakdown:
-    COMMIT_TYPE#ISSUE_ID - COMMIT_MESSAGE
+    TYPE/#ISSUE_ID - COMMIT_MESSAGE
 
 Example: (Assume 'bug' type and issue id is '#12345')
-    bug#12345 - This is a commit to resolve a bug
+    bugfix/#12345 - This is a commit to resolve a bug
 
 Command:
-    git commit -m "bug#12345 - This is a commit to resolve a bug"
+    git commit -m "bugfix/#12345 - This is a commit to resolve a bug"
 ```
 
-**Commit Types:**
+**Types:**
 - `document`    : Documentation
 - `feature`     : Feature
 - `bugfix`      : Bug Fix
 - `refactor`    : Refactorization
 - `chore`       : Misc (Dependency updates, etc)
-- `sandbox`     : Test commits for `sandbox` branch types (Not allowed for other branches)
+- `sandbox`     : Testing and experimentation
 
 ## Template for Issues
 ```


### PR DESCRIPTION
Made it so that the new naming standard is:
```
Pull Request: TYPE/#ISSUE_ID description
Branch: TYPE/#ISSUE_ID_branch_name
Commit: TYPE/#ISSUE_ID - Something else on top
```

This is to help make the `#ISSUE_ID` clickable on the GitHub interface to easily check what the ticket is about while keeping it straightforward and easy to remember