### PR TITLE
bugfix/#35 - Set deploy name to prometheus-kube-state-metrics 

### DIFF
--- a/k3s_cluster/bootstrap/default/optional_monitoring.sh
+++ b/k3s_cluster/bootstrap/default/optional_monitoring.sh
@@ -51,7 +51,7 @@ function wait_prometheus_operator() {
 
 function wait_prometheus_metrics() {
     local NS="monitoring"
-    local DEPLOY_NAME="prometheus-kube-prometheus-metrics"
+    local DEPLOY_NAME="prometheus-kube-state-metrics"
     wait_generic "${NS}" "${DEPLOY_NAME}" || return 1
 }
 


### PR DESCRIPTION
Set deploy name to prometheus-kube-state-metrics (was prometheus-kube-prometheus-metrics) in wait_prometheus_metrics