### PR TITLE
Fix Karpenter startup: set IMDS hop limit to 2

### DIFF
--- a/k3s_cluster/cluster_ec2.tf
+++ b/k3s_cluster/cluster_ec2.tf
@@ -131,7 +131,8 @@ resource "aws_instance" "controlplane_ec2_node" {
   })
 
   metadata_options {
-    http_tokens = "required"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
   }
 
   root_block_device {
@@ -187,7 +188,8 @@ resource "aws_instance" "agentplane_ec2_node" {
   })
 
   metadata_options {
-    http_tokens = "required"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
   }
 
   root_block_device {


### PR DESCRIPTION
Closes #86

## What
Sets `http_put_response_hop_limit = 2` in the `metadata_options` of both the control-plane and agent-plane EC2 instances so IMDSv2 (`http_tokens = required`) requests from pods can reach the Instance Metadata Service.

## Why
With the default hop limit of 1, IMDSv2 token requests originating inside a container's network namespace are dropped before reaching IMDS, causing Karpenter (and other AWS-SDK pods) to fail at startup. Hop limit 2 is the standard remediation for IMDSv2 + containerized workloads.

## Scope
- `k3s_cluster/cluster_ec2.tf` only — independent of the other two split-out PRs (#87, #82); merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)